### PR TITLE
Support dispatchers in plan purchases

### DIFF
--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -9,6 +9,7 @@ class Transaction extends Model
     protected $fillable = [
         'user_id',
         'plan_id',
+        'dispatchers',
         'amount',
         'status',
         'bambora_profile_id',

--- a/app/Models/UserPlan.php
+++ b/app/Models/UserPlan.php
@@ -12,6 +12,7 @@ class UserPlan extends Model
     protected $fillable = [
         'user_id',
         'plan_id',
+        'dispatchers',
         'start_date',
         'end_date',
         'status',

--- a/database/migrations/2025_07_12_000001_add_dispatchers_to_user_plans_and_transactions.php
+++ b/database/migrations/2025_07_12_000001_add_dispatchers_to_user_plans_and_transactions.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_plans', function (Blueprint $table) {
+            $table->integer('dispatchers')->default(1)->after('plan_id');
+        });
+
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->integer('dispatchers')->default(1)->after('plan_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_plans', function (Blueprint $table) {
+            $table->dropColumn('dispatchers');
+        });
+
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropColumn('dispatchers');
+        });
+    }
+};

--- a/resources/views/plans/index.blade.php
+++ b/resources/views/plans/index.blade.php
@@ -44,7 +44,7 @@
                     @foreach ($plans as $plan)
                         @php
                             $per = $plan->frequency === 'Monthly' ? 'month' : 'year';
-                            $basePrice = $plan->price; // Price per dispatcher
+                            $basePrice = $plan->sale_price ?? $plan->price; // Price per dispatcher
                         @endphp
 
                         <div class="col-lg-4 col-md-6 mb-4">

--- a/resources/views/plans/payment_form.blade.php
+++ b/resources/views/plans/payment_form.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    @php
+        $perDispatcher = $plan->sale_price ?? $plan->price;
+        $total = $perDispatcher * $dispatchers;
+    @endphp
     <style>
         /* Payment specific styles */
         .payment-card {
@@ -124,6 +128,7 @@
                                 <form id="paymentForm" method="POST"
                                     action="{{ route('plans.subscribe', $plan->id) }}">
                                     @csrf
+                                    <input type="hidden" name="dispatchers" value="{{ old('dispatchers', $dispatchers) }}">
                                     <!-- Card Information -->
                                     <div class="mb-4">
                                         <h6 class="mb-3">Card Information</h6>
@@ -192,7 +197,7 @@
                                         <button type="submit" class="btn btn-primary btn-lg" id="payButton">
                                             <span class="loading-spinner me-2" id="loadingSpinner"></span>
                                             <i class="bi bi-lock me-2"></i>
-                                            Pay {{ number_format($plan->price * $dispatchers, 2) }}
+                                            Pay {{ number_format($total, 2) }}
                                         </button>
                                     </div>
                                 </form>
@@ -224,8 +229,8 @@
                             <h5 class="mb-3">Order Summary</h5>
 
                             <div class="summary-item">
-                                <span>Pro Plan</span>
-                                <span>{{ $plan->formatted_price }}</span>
+                                <span>{{ $plan->plan_name }}</span>
+                                <span>${{ number_format($perDispatcher, 2) }}</span>
                             </div>
                             <div class="summary-item">
                                 <span>Dispatchers</span>
@@ -238,7 +243,7 @@
 
                             <div class="summary-item summary-total">
                                 <span>Total</span>
-                                <span>{{ number_format($plan->price * $dispatchers, 2) }}</span>
+                                <span>{{ number_format($total, 2) }}</span>
                             </div>
 
                             <hr class="my-3">


### PR DESCRIPTION
## Summary
- Calculate plan payments based on selected dispatcher count
- Track dispatcher totals on user plans and transactions
- Migrate database to add dispatcher columns

## Testing
- `php artisan test` *(fails: duplicate column name: user_id)*

------
https://chatgpt.com/codex/tasks/task_e_689c36f9b3788323822c9a2aa6382fba