### PR TITLE
Charge only for added dispatchers while keeping plan end date

### DIFF
--- a/resources/views/plans/payment_form.blade.php
+++ b/resources/views/plans/payment_form.blade.php
@@ -1,7 +1,9 @@
 <x-app-layout>
     @php
         $perDispatcher = $plan->sale_price ?? $plan->price;
-        $total = $perDispatcher * $dispatchers;
+        $existingDispatchers = $existingDispatchers ?? 0;
+        $additionalDispatchers = max(0, $dispatchers - $existingDispatchers);
+        $total = $perDispatcher * $additionalDispatchers;
     @endphp
     <style>
         /* Payment specific styles */
@@ -233,8 +235,12 @@
                                 <span>${{ number_format($perDispatcher, 2) }}</span>
                             </div>
                             <div class="summary-item">
-                                <span>Dispatchers</span>
-                                <span>{{ $dispatchers }}</span>
+                                <span>Current Dispatchers</span>
+                                <span>{{ $existingDispatchers }}</span>
+                            </div>
+                            <div class="summary-item">
+                                <span>Additional Dispatchers</span>
+                                <span>{{ $additionalDispatchers }}</span>
                             </div>
                             {{-- <div class="summary-item">
                                 <span>Tax</span>


### PR DESCRIPTION
## Summary
- Charge only for additional dispatchers when upgrading existing plan and keep original end date
- Update payment page to show current vs added dispatchers and calculate total for added seats only

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] duplicate column name: user_id)*

------
https://chatgpt.com/codex/tasks/task_e_689c70aedc688323a3c8b7be4d856012